### PR TITLE
Handle temporary files

### DIFF
--- a/tasks/simple_watch.js
+++ b/tasks/simple_watch.js
@@ -127,7 +127,14 @@ module.exports = function(grunt) {
 		function watchFile(filepath) {
 			if (!watchedFiles[filepath]) {
 				// add a new file to watched files
-				watchedFiles[filepath] = fs.statSync(filepath);
+				var statStructure = null;
+				try {
+					statStructure = fs.statSync(filepath);
+				} catch (e) { // StatSync can throw an error if the file has dissapeared in between
+					return;
+				}
+
+				watchedFiles[filepath] = statStructure;
 				mtimes[filepath] = +watchedFiles[filepath].mtime;
 			}
 		}


### PR DESCRIPTION
It's possible for statSync to throw an error here and crash if the file has disappeared since the call to grunts file lister and the call to watchFile. This happens most often with temporary files (vim's temporary buffers or Sublime Text 3's temporary files are where we have seen this happen most often).

This code simply catches the error and ignores it, simply not adding the file to the watch list, assuming its been deleted or is not watchable (due to other errors).

I'm not sure if the call to statSync later on in the code on line 178 can also have this problem, or if by this point it will be properly handled by the deletion handlers.
