### PR TITLE
Bugfix for grunt 1.0 / lodash 4.0 + 

### DIFF
--- a/tasks/simple_watch.js
+++ b/tasks/simple_watch.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
 		// This task is asynchronous.
 		var taskDone = this.async();
 		// Get a list of files to be watched.
-		var patterns = grunt.util._.chain(targets).pluck('files').flatten().uniq().value();
+		var patterns = grunt.util._.chain(targets).map('files').flatten().uniq().value();
 		var getFiles = grunt.file.expand.bind(grunt.file, patterns);
 
 		// The tasks to be run.


### PR DESCRIPTION
Pluck was removed in favour of map in lodash v4.0.0+ and this syntax
has been supported from at least 1.3 onwards.

This fixes #10 and is backwards compatible. 

See https://github.com/lodash/lodash/wiki/Changelog#v400
